### PR TITLE
feat(decks): custom decks

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,28 +1,37 @@
-name: Claude Auto Review with Tracking
+name: PR Review with Progress Tracking
+
+# This example demonstrates how to use the track_progress feature to get
+# visual progress tracking for PR reviews, similar to v0.x agent mode.
+
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+
 env:
   ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
   ANTHROPIC_MODEL: glm-4.5
 jobs:
-  review:
+  review-with-tracking:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Enable progress tracking
           track_progress: true
-          use_sticky_comment: true
-                    # Your custom review instructions
+
+          # Your custom review instructions
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -60,3 +69,9 @@ jobs:
           # Tools for comprehensive PR review
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+# When track_progress is enabled:
+# - Creates a tracking comment with progress checkboxes
+# - Includes all PR context (comments, attachments, images)
+# - Updates progress as the review proceeds
+# - Marks as completed when done

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -32,6 +33,9 @@ jobs:
             - Performance considerations
 
             Provide detailed feedback using inline comments for specific issues.
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,20 +22,41 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           use_sticky_comment: true
+                    # Your custom review instructions
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            Perform a comprehensive code review with the following focus areas:
+
+            1. **Code Quality**
+               - Clean code principles and best practices
+               - Proper error handling and edge cases
+               - Code readability and maintainability
+
+            2. **Security**
+               - Check for potential security vulnerabilities
+               - Validate input sanitization
+               - Review authentication/authorization logic
+
+            3. **Performance**
+               - Identify potential performance bottlenecks
+               - Review database queries for efficiency
+               - Check for memory leaks or resource issues
+
+            4. **Testing**
+               - Verify adequate test coverage
+               - Review test quality and edge cases
+               - Check for missing test scenarios
+
+            5. **Documentation**
+               - Ensure code is properly documented
+               - Verify README updates for new features
+               - Check API documentation accuracy
 
             Provide detailed feedback using inline comments for specific issues.
-            Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
+            Use top-level comments for general observations or praise.
 
+          # Tools for comprehensive PR review
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/apps/api/docs/FR-024-custom-decks.md
+++ b/apps/api/docs/FR-024-custom-decks.md
@@ -1,0 +1,37 @@
+# FR-024: Custom Decks and Saved Presets (Room-level)
+
+Scope
+-- Add room-level custom decks with host-only management over WebSocket.
+
+Contracts (shared-types)
+- `type CustomDeck = { id: string; name: string; values: string[] }`
+- `Room.customDecks?: CustomDeck[]`
+- `deck:upsert` payload: `{ deck: CustomDeck }`
+- `deck:delete` payload: `{ deckId: string }`
+- `deck:set` payload (existing): `{ deckId: DeckId }`
+
+Gateway (`RoomsGateway`)
+- Validates with Zod and enforces host-only for `deck:upsert`, `deck:delete`, and `deck:set`.
+- `deck:upsert` → `rooms.upsertCustomDeck()` then broadcast `room:state` (no progress change).
+- `deck:delete` → `rooms.deleteCustomDeck()` then broadcast `room:state`.
+- `deck:set` (existing) → `rooms.setDeck()` then `rooms.reset()` and broadcast `room:state` + `vote:progress`.
+
+Validation limits
+- Payload size cap remains 2KB.
+- Name: non-empty, max 40.
+- Values: 1–50 items; each 1–8 chars.
+
+Service (`RoomsService`)
+- `upsertCustomDeck(roomId, deck)` sanitizes and enforces unique deck name (case-insensitive) within the room (excluding the deck being updated) before delegating to the repository.
+- `deleteCustomDeck(roomId, deckId)` removes a deck; if it was active, repository unsets `deckId`.
+
+Repository
+- InMemory and Redis implementations persist `customDecks` inside the `Room` JSON and preserve TTL.
+
+Security & Privacy
+- Host-only actions guarded, consistent with `story:set` and `deck:set`.
+- `room:state` continues to omit votes and stats until reveal.
+
+Testing
+- Unit tests cover host-only guards, Zod validation, broadcast behavior, and round-tripping of `customDecks` via `room:state`.
+

--- a/apps/api/src/app/rooms/repository/rooms.repository.ts
+++ b/apps/api/src/app/rooms/repository/rooms.repository.ts
@@ -1,4 +1,4 @@
-import type { DeckId, Participant, Room, Story } from '@scrum-poker/shared-types';
+import type { CustomDeck, DeckId, Participant, Room, Story } from '@scrum-poker/shared-types';
 import type { RoomsBackend } from './tokens';
 
 export interface RoomsRepository {
@@ -19,4 +19,6 @@ export interface RoomsRepository {
   setRevealed(roomId: string, revealed: boolean): Promise<Room>;
   setStory(roomId: string, story: Story | undefined): Promise<Room>;
   setDeck(roomId: string, deckId: DeckId): Promise<Room>;
+  upsertCustomDeck(roomId: string, deck: CustomDeck): Promise<Room>;
+  deleteCustomDeck(roomId: string, deckId: string): Promise<Room>;
 }

--- a/apps/shared-types/src/lib/domain.ts
+++ b/apps/shared-types/src/lib/domain.ts
@@ -25,6 +25,8 @@ export interface Story {
   notes?: string;
 }
 
+export type CustomDeck = { id: string; name: string; values: string[] };
+
 export interface Room {
   id: string;
   createdAt: number; // epoch ms
@@ -33,6 +35,8 @@ export interface Room {
   // Optional voting state
   story?: Story;
   deckId?: DeckId;
+  // Room-owned custom decks
+  customDecks?: CustomDeck[];
   revealed?: boolean;
   // votes keyed by participant id; values are card identifiers
   votes?: Record<string, string>;

--- a/apps/shared-types/src/lib/public-api.spec.ts
+++ b/apps/shared-types/src/lib/public-api.spec.ts
@@ -13,6 +13,9 @@ import type {
   StorySetPayload,
   DeckSetPayload,
   VoteProgressEvent,
+  CustomDeck,
+  DeckUpsertPayload,
+  DeckDeletePayload,
 } from '../index';
 
 // This spec ensures the public API surface remains stable by
@@ -56,8 +59,12 @@ describe('shared-types public API', () => {
     const reveal: VoteRevealPayload = {};
     const story: StorySetPayload = { story: { id: 'S-1', title: 'Implement feature', notes: 'Acceptance & dev notes' } };
     const deck: DeckSetPayload = { deckId: 'fibonacci' };
+    // Custom deck contracts
+    const custom: CustomDeck = { id: 'half', name: 'Half Steps', values: ['0.5', '1', '1.5'] };
+    const upsert: DeckUpsertPayload = { deck: custom };
+    const del: DeckDeletePayload = { deckId: 'half' };
     const progress: VoteProgressEvent = { count: 1, total: 3, votedIds: ['1'] };
-    void join; void err; void cast; void reset; void reveal; void story; void deck; void progress;
+    void join; void err; void cast; void reset; void reveal; void story; void deck; void custom; void upsert; void del; void progress;
 
     expect(true).toBe(true);
   });

--- a/apps/shared-types/src/lib/ws-contracts.ts
+++ b/apps/shared-types/src/lib/ws-contracts.ts
@@ -1,5 +1,5 @@
 // WebSocket event and payload contracts
-import type { DeckId, Story,Role } from './domain';
+import type { DeckId, Story, Role, CustomDeck } from './domain';
 
 export interface RoomJoinPayload {
   roomId: string;
@@ -32,6 +32,15 @@ export interface StorySetPayload {
 
 export interface DeckSetPayload {
   deckId: DeckId;
+}
+
+// Custom deck management (host-only)
+export interface DeckUpsertPayload {
+  deck: CustomDeck;
+}
+
+export interface DeckDeletePayload {
+  deckId: string;
 }
 
 // Vote progress event (no values leaked)

--- a/apps/web/docs/FR-024-custom-decks.md
+++ b/apps/web/docs/FR-024-custom-decks.md
@@ -1,0 +1,29 @@
+# FR-024: Custom Decks and Saved Presets (Room-level)
+
+Summary
+- Hosts can create, edit, delete, and select custom vote decks per room.
+- Selecting any deck (preset or custom) clears votes, unreveals, and updates all clients.
+
+UI
+- Host Controls show a "Deck" select grouped as Presets (Fibonacci, T‑Shirt) and Custom (room decks).
+- Manage actions are wired via component helpers (`saveCustomDeck`, `deleteCustomDeck`) which emit socket events.
+
+Events
+- `deck:upsert` → `{ deck: { id, name, values[] } }` (host-only)
+- `deck:delete` → `{ deckId }` (host-only)
+- `deck:set` → `{ deckId }` (host-only, clears votes via server reset)
+
+Validations
+- Name: non-empty, max 40 chars.
+- Values: 1–50 items; each value non-empty, max 8 chars.
+
+State
+- `Room.customDecks?: { id: string; name: string; values: string[] }[]` is included in `room:state`.
+- When `room.deckId` matches a custom deck id, vote cards render using that deck’s values.
+
+Accessibility
+- No changes to card focus/keyboard handling; `VoteCardsComponent` still manages focus and selection.
+
+Notes
+- Decks are room-local and expire with the room TTL. Future work can introduce user/workspace-level presets.
+

--- a/apps/web/public/i18n/en.json
+++ b/apps/web/public/i18n/en.json
@@ -48,7 +48,8 @@
         "fibonacci": "Fibonacci",
         "tshirt": "T‑Shirt sizes"
       },
-      "deckPreset": "Deck Preset",
+      "deckPreset": "Deck",
+      "manage": "Manage Decks",
       "reset": "Reset",
       "reveal": "Reveal",
       "revote": "Revote",

--- a/apps/web/src/app/room/manage-decks/manage-decks.component.css
+++ b/apps/web/src/app/room/manage-decks/manage-decks.component.css
@@ -1,0 +1,3 @@
+.modal-backdrop { position: fixed; inset: 0; background: rgb(2 6 23 / 0.5); display: grid; place-items: center; z-index: 50; }
+.modal { width: 100%; max-width: 640px; }
+.help { line-height: 1.2; }

--- a/apps/web/src/app/room/manage-decks/manage-decks.component.html
+++ b/apps/web/src/app/room/manage-decks/manage-decks.component.html
@@ -1,0 +1,53 @@
+@if (open) {
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="mdTitle" appUiFocusTrap>
+    <div class="modal">
+      <app-ui-card class="block">
+        <div class="flex items-center justify-between">
+          <h3 id="mdTitle" class="text-base font-semibold text-slate-900">Manage Decks</h3>
+          <button type="button" appUiButton variant="secondary" (click)="dismiss.emit()">Close</button>
+        </div>
+
+        <div class="mt-4">
+          <h4 class="text-sm font-medium text-slate-800">Create / Edit</h4>
+          <div class="mt-2 grid grid-cols-1 gap-3">
+            <div>
+              <label for="deckId" class="block text-sm text-slate-700">Deck ID</label>
+              <input id="deckId" appUiInput [(ngModel)]="modelId" placeholder="e.g. half" />
+            </div>
+            <div>
+              <label for="deckName" class="block text-sm text-slate-700">Name</label>
+              <input id="deckName" appUiInput [(ngModel)]="modelName" placeholder="e.g. Half Steps" />
+            </div>
+            <div>
+              <label for="deckValues" class="block text-sm text-slate-700">Values (one per line)</label>
+              <textarea id="deckValues" appUiInput rows="6" [(ngModel)]="valuesTextarea" placeholder="0.5\n1\n1.5\n2"></textarea>
+              <p class="help text-xs text-slate-500 mt-1">1–50 values; each up to 8 characters.</p>
+            </div>
+            <div class="flex justify-end">
+              <button id="saveDeckBtn" appUiButton (click)="save()" [disabled]="!modelId.trim() || !modelName.trim() || !valuesTextarea.trim()">Save</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-6">
+          <h4 class="text-sm font-medium text-slate-800">Existing</h4>
+          @if (decks.length === 0) {
+            <p class="text-xs text-slate-500 mt-1">No custom decks yet.</p>
+          } @else {
+            <ul class="mt-2 space-y-2">
+              @for (d of decks; track d.id) {
+                <li class="flex items-center justify-between text-sm">
+                  <div class="min-w-0">
+                    <span class="font-medium">{{ d.name }}</span>
+                    <span class="text-slate-500">({{ d.id }})</span>
+                  </div>
+                  <button class="deleteDeckBtn" appUiButton variant="secondary" size="sm" (click)="deleteDeck(d.id)">Delete</button>
+                </li>
+              }
+            </ul>
+          }
+        </div>
+      </app-ui-card>
+    </div>
+  </div>
+}

--- a/apps/web/src/app/room/manage-decks/manage-decks.component.ts
+++ b/apps/web/src/app/room/manage-decks/manage-decks.component.ts
@@ -1,0 +1,59 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { UiCardComponent } from '../../ui/card/card.component';
+import { UiButtonDirective } from '../../ui/button.directive';
+import { UiInputDirective } from '../../ui/input.directive';
+import { UiFocusTrapDirective } from '../../ui/focus-trap.directive';
+
+export interface EditableDeck {
+  id: string;
+  name: string;
+  values: string[];
+}
+
+@Component({
+  selector: 'app-manage-decks',
+  standalone: true,
+  imports: [CommonModule, FormsModule, UiCardComponent, UiButtonDirective, UiInputDirective, UiFocusTrapDirective],
+  templateUrl: './manage-decks.component.html',
+  styleUrls: ['./manage-decks.component.css'],
+})
+export class ManageDecksComponent {
+  @Input() open = false;
+  @Input() decks: EditableDeck[] = [];
+  @Output() dismiss = new EventEmitter<void>();
+  @Output() upsert = new EventEmitter<EditableDeck>();
+  @Output() del = new EventEmitter<string>();
+
+  // Simple create form state
+  modelId = '';
+  modelName = '';
+  valuesTextarea = '';
+
+  resetForm() {
+    this.modelId = '';
+    this.modelName = '';
+    this.valuesTextarea = '';
+  }
+
+  save() {
+    const id = (this.modelId || '').trim();
+    const name = (this.modelName || '').trim();
+    const values = (this.valuesTextarea || '')
+      .split(/\r?\n/)
+      .map((v) => v.trim())
+      .filter((v) => !!v);
+    if (!id || !name || values.length === 0) return;
+    if (values.length > 50 || values.some((v) => v.length > 8)) return;
+    this.upsert.emit({ id, name, values });
+    this.resetForm();
+    this.dismiss.emit();
+  }
+
+  deleteDeck(id: string) {
+    const v = (id || '').trim();
+    if (!v) return;
+    this.del.emit(v);
+  }
+}

--- a/apps/web/src/app/room/room.component.html
+++ b/apps/web/src/app/room/room.component.html
@@ -218,19 +218,24 @@
       <app-ui-card class="block host-controls">
         <h3 class="text-base font-semibold text-slate-900">{{ 'room.host.title' | transloco }}</h3>
         <div class="mt-3 deck-select">
-          <label
-            for="deckSelect"
-            class="block text-sm font-medium text-slate-700"
-            >{{ 'room.host.deckPreset' | transloco }}</label
-          >
+          <label for="deckSelect" class="block text-sm font-medium text-slate-700">{{ 'room.host.deckPreset' | transloco }}</label>
           <select
             id="deckSelect"
             class="mt-1 block w-full rounded-md border-slate-200 bg-white text-slate-900 shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500/40"
             [ngModel]="deckId()"
             (ngModelChange)="changeDeck($event)"
           >
-            <option value="fibonacci">{{ 'room.host.deck.fibonacci' | transloco }}</option>
-            <option value="tshirt">{{ 'room.host.deck.tshirt' | transloco }}</option>
+            <optgroup label="Presets">
+              <option value="fibonacci">{{ 'room.host.deck.fibonacci' | transloco }}</option>
+              <option value="tshirt">{{ 'room.host.deck.tshirt' | transloco }}</option>
+            </optgroup>
+            @if (customDecks().length > 0) {
+            <optgroup label="Custom">
+              @for (d of customDecks(); track d.id) {
+              <option [value]="d.id">{{ d.name }}</option>
+              }
+            </optgroup>
+            }
           </select>
         </div>
         <div class="mt-4 flex items-center gap-2">

--- a/apps/web/src/app/room/room.component.html
+++ b/apps/web/src/app/room/room.component.html
@@ -247,10 +247,18 @@
           } @else {
             <button appUiButton (click)="revote()">{{ 'room.host.revote' | transloco }}</button>
           }
+          <button appUiButton variant="secondary" (click)="openManageDecks()">{{ 'room.host.manage' | transloco }}</button>
         </div>
       </app-ui-card>
       }
     </div>
   </section>
   }
+  <app-manage-decks
+    [open]="showManageDecks()"
+    [decks]="customDecks()"
+    (dismiss)="closeManageDecks()"
+    (upsert)="saveCustomDeck($event)"
+    (del)="deleteCustomDeck($event)"
+  />
 </div>

--- a/apps/web/src/app/room/room.component.spec.ts
+++ b/apps/web/src/app/room/room.component.spec.ts
@@ -668,14 +668,30 @@ describe('RoomComponent (Custom Decks)', () => {
     } as any;
     comp.socket = fakeSocket;
 
-    // Save a deck
-    comp.saveCustomDeck({ id: 'half', name: 'Half Steps', values: ['0.5','1','1.5'] });
-    expect(fakeSocket.emit).toHaveBeenCalledWith('deck:upsert', {
-      deck: { id: 'half', name: 'Half Steps', values: ['0.5','1','1.5'] },
-    });
+    // Open modal and use its UI to save/delete
+    comp.openManageDecks();
+    fixture.detectChanges();
 
-    // Delete a deck
-    comp.deleteCustomDeck('half');
+    const html = fixture.nativeElement as HTMLElement;
+    // Fill in id, name, values
+    (html.querySelector('#deckId') as HTMLInputElement).value = 'half';
+    (html.querySelector('#deckId') as HTMLInputElement).dispatchEvent(new Event('input'));
+    (html.querySelector('#deckName') as HTMLInputElement).value = 'Half Steps';
+    (html.querySelector('#deckName') as HTMLInputElement).dispatchEvent(new Event('input'));
+    (html.querySelector('#deckValues') as HTMLTextAreaElement).value = '0.5\n1\n1.5';
+    (html.querySelector('#deckValues') as HTMLTextAreaElement).dispatchEvent(new Event('input'));
+
+    // Click Save
+    fixture.detectChanges();
+    (html.querySelector('#saveDeckBtn') as HTMLButtonElement).click();
+    expect(fakeSocket.emit).toHaveBeenCalledWith('deck:upsert', { deck: { id: 'half', name: 'Half Steps', values: ['0.5','1','1.5'] } });
+
+    // Re-open and delete from list
+    comp.showManageDecks.set(true);
+    comp.customDecks.set([{ id: 'half', name: 'Half Steps', values: ['0.5','1','1.5'] }]);
+    fixture.detectChanges();
+    const delBtn = html.querySelector('.deleteDeckBtn') as HTMLButtonElement;
+    delBtn.click();
     expect(fakeSocket.emit).toHaveBeenCalledWith('deck:delete', { deckId: 'half' });
   });
 

--- a/apps/web/src/app/room/room.component.ts
+++ b/apps/web/src/app/room/room.component.ts
@@ -30,6 +30,7 @@ import { UiCheckboxDirective } from '../ui/checkbox.directive';
 import { UiCardComponent } from '../ui/card/card.component';
 import { UiFocusTrapDirective } from '../ui/focus-trap.directive';
 import { TranslocoPipe } from '@jsverse/transloco';
+import { ManageDecksComponent } from './manage-decks/manage-decks.component';
 import { I18nService } from '../i18n/i18n.service';
 
 @Component({
@@ -46,6 +47,7 @@ import { I18nService } from '../i18n/i18n.service';
     UiCardComponent,
     UiFocusTrapDirective,
     TranslocoPipe,
+    ManageDecksComponent,
   ],
   templateUrl: './room.component.html',
   styleUrls: ['./room.component.css'],
@@ -84,6 +86,7 @@ export class RoomComponent implements OnDestroy {
   votedIds = signal<string[]>([]);
   // Join modal visibility
   showJoinModal = signal(false);
+  showManageDecks = signal(false);
 
   private socket?: Socket;
   private socketId = signal<string>('');
@@ -378,6 +381,14 @@ export class RoomComponent implements OnDestroy {
     if (this.myRole() !== 'host') return;
     const socket = this.connect();
     socket.emit('deck:set', { deckId });
+  }
+
+  openManageDecks() {
+    if (this.myRole() !== 'host') return;
+    this.showManageDecks.set(true);
+  }
+  closeManageDecks() {
+    this.showManageDecks.set(false);
   }
 
   // ---- Manage Decks (host-only helpers) ----

--- a/apps/web/src/app/room/room.component.ts
+++ b/apps/web/src/app/room/room.component.ts
@@ -74,6 +74,7 @@ export class RoomComponent implements OnDestroy {
   storyTitleModel = '';
   storyNotesModel = '';
   deckId = signal<DeckId>('fibonacci');
+  customDecks = signal<NonNullable<Room['customDecks']>>([]);
   votes = signal<Record<string, string>>({});
   // FR-009 results stats
   stats = signal<VoteStats | null>(null);
@@ -199,6 +200,7 @@ export class RoomComponent implements OnDestroy {
       this.storyTitleModel = room.story?.title ?? '';
       this.storyNotesModel = room.story?.notes ?? '';
       const prevDeck = this.deckId();
+      this.customDecks.set(room.customDecks ?? []);
       const nextDeck: DeckId = (room.deckId ?? 'fibonacci') as DeckId;
       this.deckId.set(nextDeck);
       // Clear local selection if deck changed so UI doesn't show a stale highlight
@@ -364,6 +366,9 @@ export class RoomComponent implements OnDestroy {
   deckValues() {
     const d = this.deckId();
     if (d === 'tshirt') return RoomComponent.TSHIRT;
+    // If a custom deck is active, return its values
+    const custom = this.customDecks().find((cd) => cd.id === d);
+    if (custom) return custom.values ?? [];
     // Default to Fibonacci if unknown deck id
     return RoomComponent.FIBONACCI;
   }
@@ -373,6 +378,25 @@ export class RoomComponent implements OnDestroy {
     if (this.myRole() !== 'host') return;
     const socket = this.connect();
     socket.emit('deck:set', { deckId });
+  }
+
+  // ---- Manage Decks (host-only helpers) ----
+  saveCustomDeck(deck: { id: string; name: string; values: string[] }) {
+    if (this.myRole() !== 'host') return;
+    const id = (deck?.id ?? '').toString().trim();
+    const name = (deck?.name ?? '').toString().trim();
+    const values = Array.isArray(deck?.values) ? deck.values.map((v) => (v ?? '').toString().trim()).filter((v) => !!v) : [];
+    if (!id || !name || values.length === 0) return;
+    const socket = this.connect();
+    socket.emit('deck:upsert', { deck: { id, name, values } });
+  }
+
+  deleteCustomDeck(deckId: string) {
+    if (this.myRole() !== 'host') return;
+    const id = (deckId ?? '').toString().trim();
+    if (!id) return;
+    const socket = this.connect();
+    socket.emit('deck:delete', { deckId: id });
   }
 
   private buildShareUrl(role: 'observer' | 'player'): string {


### PR DESCRIPTION
This pull request introduces room-level custom decks to the Scrum Poker application, allowing hosts to create, edit, delete, and select custom vote decks for their rooms. The implementation spans backend contracts, repository logic, gateway validation, service methods, and frontend documentation, ensuring host-only management and robust validation. Custom decks are persisted in both in-memory and Redis repositories, and their state is broadcast to all clients whenever modified.

**Custom Decks Feature Implementation**

_Backend Contracts and Types:_
* Added `CustomDeck` type and updated `Room` to include an optional `customDecks` array, along with new WebSocket payload types for deck management (`DeckUpsertPayload`, `DeckDeletePayload`). [[1]](diffhunk://#diff-873b4e8e154bcf80dd562018c1435537df89aa6663bf8efe72fd15ffd79cb04aR28-R29) [[2]](diffhunk://#diff-873b4e8e154bcf80dd562018c1435537df89aa6663bf8efe72fd15ffd79cb04aR38-R39) [[3]](diffhunk://#diff-6ef2121150a04dd6b0d767af7308a938a903b6106499afddd067116b01a68e0cL2-R2) [[4]](diffhunk://#diff-6ef2121150a04dd6b0d767af7308a938a903b6106499afddd067116b01a68e0cR37-R45)

_Repository Logic:_
* Implemented `upsertCustomDeck` and `deleteCustomDeck` methods in both `InMemoryRoomsRepository` and `RedisRoomsRepository` to persist custom decks and handle active deck removal when deleted. [[1]](diffhunk://#diff-97fe0995b6dd2eb95025468206b35376e0b0ccfb1d58c4ab7b907419d8176b90R129-R148) [[2]](diffhunk://#diff-237cfb9e29ac6f4f7bd33a01bdcee1cc581fe94538b04bc505f8f465fd755ee5R188-R209) [[3]](diffhunk://#diff-fb6a1bfe9d02e385672385aaa607af54f0cf70bbce590c6a19b18c440c481e0aR22-R23)

_Gateway and Service Enhancements:_
* Extended `RoomsGateway` to validate payloads, enforce host-only actions for custom deck management, and broadcast updated room state on changes. Added corresponding service methods for sanitization, uniqueness, and validation. [[1]](diffhunk://#diff-424a08dce434a434ae01ad009ef9c657d2e28bdddca92b27fb689884281008fcR85-R100) [[2]](diffhunk://#diff-424a08dce434a434ae01ad009ef9c657d2e28bdddca92b27fb689884281008fcR520-R568) [[3]](diffhunk://#diff-c219da8dcbc3810443febdf000582d39361a4824eb9480ae4538a3b6f0994b66R95-R130)

_Test Coverage:_
* Added unit tests to verify host-only guards, validation logic, and broadcast behavior for custom deck events.

**Documentation and Frontend Integration**

_Documentation:_
* Added technical and user-facing documentation describing the custom decks feature, including payload contracts, UI controls, validation rules, and state changes. [[1]](diffhunk://#diff-c34c8e77789b370ef6448fc9e3b2efd0053f562d85d457d96e9ba6ef6f3c5aceR1-R37) [[2]](diffhunk://#diff-7c2b15dec0dd0cff7650b37d05ae039bd20d9835242968e0a41f6a286ef44512R1-R29)

These changes collectively enable hosts to manage custom vote decks at the room level, with strong validation, security, and real-time updates to all participants.